### PR TITLE
Implement full page screenshot capture

### DIFF
--- a/fixtures/mvt_remote_runner.py
+++ b/fixtures/mvt_remote_runner.py
@@ -142,7 +142,22 @@ class MVTRemoteRunner:
             self.webdriver.driver.save_screenshot(temp_file)
             temp_files.append(temp_file)
 
-        self.stitch_images(temp_files, screenshot_path)
+        if "css" in self.get_test_name():
+            total = len(temp_files)
+            quarter = (total + 3) // 4
+
+            for i in range(4):
+                start = i * quarter
+                end = min((i + 1) * quarter, total)
+
+                if start >= total:
+                    break
+
+                output = screenshot_path.replace(".png", f"_part{i + 1}.png")
+                self.stitch_images(temp_files[start:end], output)
+
+        else:
+            self.stitch_images(temp_files, screenshot_path)
 
     def collect_screenshot(self, suffix=None):
         base_name = self.get_test_name()

--- a/fixtures/mvt_remote_runner.py
+++ b/fixtures/mvt_remote_runner.py
@@ -113,7 +113,7 @@ class MVTRemoteRunner:
                 images.append(Image.open(path))
 
             if not images:
-                    return
+                return
 
             width = max(img.width for img in images)
             total_height = sum(img.height for img in images)
@@ -126,14 +126,14 @@ class MVTRemoteRunner:
 
             stitched.save(output_file)
         finally:
-                for img in images:
-                    try:
-                        img.close()
-                    except Exception:
-                        pass
-                for path in image_files:
-                    if os.path.exists(path):
-                        os.remove(path)
+            for img in images:
+                try:
+                    img.close()
+                except Exception:
+                    pass
+            for path in image_files:
+                if os.path.exists(path):
+                    os.remove(path)
 
     def collect_fullpage_screenshot(self, screenshot_path):
         page_height = self.webdriver.driver.execute_script("return document.documentElement.scrollHeight")

--- a/fixtures/mvt_remote_runner.py
+++ b/fixtures/mvt_remote_runner.py
@@ -107,20 +107,33 @@ class MVTRemoteRunner:
         self.logger.assertion(not failed_tests, f"{len(failed_tests)} test failed: {failed_tests}.")
 
     def stitch_images(self, image_files, output_file):
-        images = [Image.open(img) for img in image_files]
-        width = images[0].width
-        total_height = sum(img.height for img in images)
-        stitched = Image.new("RGB", (width, total_height))
-        y_offset = 0
+        images = []
+        try:
+            for path in image_files:
+                images.append(Image.open(path))
 
-        for img in images:
-            stitched.paste(img, (0, y_offset))
-            y_offset += img.height
+            if not images:
+                    return
 
-        stitched.save(output_file)
+            width = max(img.width for img in images)
+            total_height = sum(img.height for img in images)
+            stitched = Image.new(images[0].mode, (width, total_height))
+            y_offset = 0
 
-        for img in image_files:
-            os.remove(img)
+            for img in images:
+                stitched.paste(img, (0, y_offset))
+                y_offset += img.height
+
+            stitched.save(output_file)
+        finally:
+                for img in images:
+                    try:
+                        img.close()
+                    except Exception:
+                        pass
+                for path in image_files:
+                    if os.path.exists(path):
+                        os.remove(path)
 
     def collect_fullpage_screenshot(self, screenshot_path):
         page_height = self.webdriver.driver.execute_script("return document.documentElement.scrollHeight")

--- a/fixtures/mvt_remote_runner.py
+++ b/fixtures/mvt_remote_runner.py
@@ -22,6 +22,7 @@ import os
 import pytest
 from time import sleep, time
 from utils import retry_on_failure
+from PIL import Image
 
 SCREENSHOTS_DIR = "screenshots"
 MVT_RESULTS_DIR = "results"
@@ -105,6 +106,44 @@ class MVTRemoteRunner:
         failed_tests = [test["name"] for test in self._results["tests"] if test["status"] == "failed"]
         self.logger.assertion(not failed_tests, f"{len(failed_tests)} test failed: {failed_tests}.")
 
+    def stitch_images(self, image_files, output_file):
+        images = [Image.open(img) for img in image_files]
+        width = images[0].width
+        total_height = sum(img.height for img in images)
+        stitched = Image.new("RGB", (width, total_height))
+        y_offset = 0
+
+        for img in images:
+            stitched.paste(img, (0, y_offset))
+            y_offset += img.height
+
+        stitched.save(output_file)
+
+        for img in image_files:
+            os.remove(img)
+
+    def collect_fullpage_screenshot(self, screenshot_path):
+        page_height = self.webdriver.driver.execute_script("return document.documentElement.scrollHeight")
+        visible_height = self.webdriver.driver.execute_script("return window.innerHeight")
+
+        if page_height <= visible_height:
+            self.webdriver.driver.save_screenshot(screenshot_path)
+            return
+
+        self.logger.debug(f"Page height={page_height}, visible height={visible_height}")
+        temp_files = []
+        positions = list(range(0, page_height, visible_height))
+
+        for i, y in enumerate(positions):
+
+            self.webdriver.driver.execute_script(f"window.scrollTo(0, {y})")
+            sleep(1)
+            temp_file = screenshot_path.replace(".png", f"_part_{i}.png")
+            self.webdriver.driver.save_screenshot(temp_file)
+            temp_files.append(temp_file)
+
+        self.stitch_images(temp_files, screenshot_path)
+
     def collect_screenshot(self, suffix=None):
         base_name = self.get_test_name()
         if suffix:
@@ -112,7 +151,7 @@ class MVTRemoteRunner:
         else:
             file_name = f"{base_name}.png"
         screenshot_path = os.path.join(self._result_dir, SCREENSHOTS_DIR, file_name)
-        self.webdriver.stb.take_screenshot(screenshot_path)
+        self.collect_fullpage_screenshot(screenshot_path)
 
     def save_result(self):
         if getattr(self, "_last_suite", None) in MVT_EXTENSION_TESTS:

--- a/mvt_requirements.txt
+++ b/mvt_requirements.txt
@@ -28,3 +28,4 @@ websocket-client==0.56.0
 wsproto==1.2.0
 websockets==15.0.1
 cryptography==43.0.0
+Pillow==11.1.0


### PR DESCRIPTION
Implement full page screenshot capture for HTML, CSS AND JS tests by capturing multiple screenshots for every scroll down action and then stitching it all together as 1 image. 

For CSS test, page length was very big so distributed the full result in 4 images